### PR TITLE
Enabling grpc web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN addgroup --gid 10001 notroot \
 
 WORKDIR /app
 COPY --from=build /app .
-
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 USER notroot:notroot
 ENV ASPNETCORE_URLS="http://+:8080"
 ENV DOTNET_EnableDiagnostics=1

--- a/src/IdpServiceFacade/IdpServiceFacade.csproj
+++ b/src/IdpServiceFacade/IdpServiceFacade.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -59,6 +59,7 @@
         <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
         <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.71.0" />
         <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.71.0" />
+        <PackageReference Include="Grpc.AspNetCore.Web" Version="2.71.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
         <PackageReference Include="microsoft.codeanalysis.bannedapianalyzers" Version="5.0.0-1.25277.114">
             <PrivateAssets>all</PrivateAssets>

--- a/src/IdpServiceFacade/Program.cs
+++ b/src/IdpServiceFacade/Program.cs
@@ -61,7 +61,7 @@ app.MapGrpcHealthChecksService();
 app.MapGrpcReflectionService();
 app.UseEndpoints(endpoints =>
 {
-    endpoints.MapGrpcService<IUserService>().EnableGrpcWeb();
+    _ = endpoints.MapGrpcService<IUserService>().EnableGrpcWeb();
 });
 app.MapMetrics("/metricsz");
 app.MapHealthChecks("/healthz/live", new HealthCheckOptions { Predicate = registration => registration.Tags.Contains("live") });

--- a/src/IdpServiceFacade/Program.cs
+++ b/src/IdpServiceFacade/Program.cs
@@ -1,3 +1,5 @@
+using Abstractions;
+
 using Innago.Security.IdpServiceFacade;
 using Innago.Security.IdpServiceFacade.Services;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -47,6 +49,7 @@ WebApplication app = builder.Build();
 
 app.UseRouting();
 app.UseGrpcMetrics();
+app.UseGrpcWeb();
 app.UseHttpMetrics();
 app.UseForwardedHeaders();
 app.UseSerilogRequestLogging();
@@ -56,6 +59,10 @@ app.MapGrpcService<UserService>();
 app.MapGrpcHealthChecksService();
 
 app.MapGrpcReflectionService();
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapGrpcService<IUserService>().EnableGrpcWeb();
+});
 app.MapMetrics("/metricsz");
 app.MapHealthChecks("/healthz/live", new HealthCheckOptions { Predicate = registration => registration.Tags.Contains("live") });
 app.MapHealthChecks("/healthz/ready", new HealthCheckOptions { Predicate = registration => registration.Tags.Contains("ready") }); 


### PR DESCRIPTION
Add gRPC-Web support and update dependencies

- Updated `IdpServiceFacade.csproj` to include `Grpc.AspNetCore.Web` version `2.71.0`.
- Added a using directive for `Abstractions` in `Program.cs`.
- Modified the gRPC middleware pipeline to include `app.UseGrpcWeb()`.
- Mapped `IUserService` with `EnableGrpcWeb()` for improved web client compatibility.

## Summary by Sourcery

Enable gRPC-Web support in the IdpServiceFacade by updating dependencies and configuring the middleware pipeline.

New Features:
- Add gRPC-Web support for web clients by enabling grpc-web on the IUserService gRPC endpoint.

Enhancements:
- Import Abstractions namespace in Program.cs.
- Add app.UseGrpcWeb() to the middleware pipeline and enable grpc-web on the gRPC service mapping.

Build:
- Update IdpServiceFacade.csproj to include Grpc.AspNetCore.Web version 2.71.0.